### PR TITLE
No-JIRA: Create CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# These owners will be the default owners for everything in
+# the repo.
+*                            @SportsToken/frontend


### PR DESCRIPTION
# Description
This creates code owners who will need to sign off on a PR before it is merged. 
If you are on the @SportsToken/frontend team you will be automatically a codeowner of this repo and every PR will need at least one of you to sign off. This way we can ensure at least one person who has good context to the wider project has signed off on an incoming PR