### PR TITLE
AX-409 pixel overflow does not show when keyboard is up on the pool page

### DIFF
--- a/lib/pages/DesktopPool.dart
+++ b/lib/pages/DesktopPool.dart
@@ -92,20 +92,23 @@ class _DesktopPoolState extends State<DesktopPool> {
     double layoutWdt = isWeb ? _width * 0.8 : _width * 0.9;
 
     print(_width);
-    return Container(
-        width: _width,
-        height: _height - AppBar().preferredSize.height,
-        //Top margin of Pool section is equal to height + 1 of AppBar on mobile only
-        margin: isWeb
-            ? EdgeInsets.zero
-            : EdgeInsets.only(top: AppBar().preferredSize.height + 10),
-        alignment: Alignment.center,
-        child: Container(
-            width: layoutWdt,
-            height: layoutHgt,
-            child: (isAllLiquidity)
-                ? allLiquidityLayout(layoutHgt, layoutWdt)
-                : myLiquidityLayout(layoutHgt, layoutWdt)));
+    return SingleChildScrollView(
+      physics: ClampingScrollPhysics(),
+      child: Container(
+          width: _width,
+          height: _height - AppBar().preferredSize.height,
+          //Top margin of Pool section is equal to height + 1 of AppBar on mobile only
+          margin: isWeb
+              ? EdgeInsets.zero
+              : EdgeInsets.only(top: AppBar().preferredSize.height + 10),
+          alignment: Alignment.center,
+          child: Container(
+              width: layoutWdt,
+              height: layoutHgt,
+              child: (isAllLiquidity)
+                  ? allLiquidityLayout(layoutHgt, layoutWdt)
+                  : myLiquidityLayout(layoutHgt, layoutWdt))),
+    );
   }
 
   Widget allLiquidityLayout(double layoutHgt, double layoutWdt) {


### PR DESCRIPTION
# Description
This ticket fixes the issue when the contents overflow while the keyboard is up when on the pool page. 

Fixes Jira Ticket # 409
https://athletex.atlassian.net/jira/software/projects/AX/boards/1?selectedIssue=AX-409

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Is this a UI Change? If so please include screenshot of before and after states below
## Before
![PKUB](https://user-images.githubusercontent.com/89420193/164366238-e6ee4ddd-ae27-4c75-8198-422993e4e7fe.PNG)

## After
![PKUA](https://user-images.githubusercontent.com/89420193/164366249-8ad229ac-1990-40cc-ab00-58fafe3aea21.PNG)


# How Has This Been Tested?
Ran the app using Google developer tools and the Pixel 2 API 30

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have assigned 2 reviewers to check my work
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
