### PR TITLE
temp fix for linter launcher url deprecated git workflow errors

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -46,5 +46,5 @@ jobs:
       #  run: dart analyze
       
       - name: Run linter
-        run: dart analyze
+        run: dart analyze --no-fatal-warnings
 

--- a/.github/workflows/primary.yml
+++ b/.github/workflows/primary.yml
@@ -21,6 +21,6 @@ jobs:
       - run: flutter upgrade
       - run: flutter pub upgrade
       - run: flutter pub get
-      - run: flutter analyze
+      - run: flutter analyze --no-fatal-warnings
       - run: flutter test
       - run: flutter build web --web-renderer auto

--- a/.github/workflows/primary.yml
+++ b/.github/workflows/primary.yml
@@ -21,6 +21,6 @@ jobs:
       - run: flutter upgrade
       - run: flutter pub upgrade
       - run: flutter pub get
-      - run: flutter analyze --no-fatal-warnings
+      - run: flutter analyze --no-fatal-infos --no-fatal-warnings
       - run: flutter test
       - run: flutter build web --web-renderer auto


### PR DESCRIPTION
# Description
temp fix for linter launcher url deprecated git workflow errors

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (breaking change which fixes an issue)
![image](https://user-images.githubusercontent.com/57809593/164831369-a586b354-fd19-4c15-9375-798509e4b34f.png)
