### PR TITLE
[Pool Page - My Liquidity] - Default set the Remove liquidity slider …

### DIFF
--- a/lib/pages/pool/MyLiqudity/MyLiquidity.dart
+++ b/lib/pages/pool/MyLiqudity/MyLiquidity.dart
@@ -693,6 +693,7 @@ class _MyLiquidityState extends State<MyLiquidity> {
                                         onPressed: () {
                                           setState(() {
                                             currentTabIndex = 0;
+                                            value = 0;
                                           });
                                         },
                                         child: Text(

--- a/lib/pages/pool/MyLiqudity/MyLiquidity.dart
+++ b/lib/pages/pool/MyLiqudity/MyLiquidity.dart
@@ -694,6 +694,8 @@ class _MyLiquidityState extends State<MyLiquidity> {
                                           setState(() {
                                             currentTabIndex = 0;
                                             value = 0;
+                                            poolController
+                                                .removePercentage = value;
                                           });
                                         },
                                         child: Text(


### PR DESCRIPTION
…to 0%

# Description
when user clicks cancel slider to zero so it defaults to zero when selecting another pool

Fixes Jira Ticket # https://athletex.atlassian.net/browse/AX-546

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have assigned 2 reviewers to check my work
- [x] My changes generate no new warnings