### PR TITLE
AX 543 - [Pool Page - Add Liquidity] - Display no pool created text if the LP does not exist

### DIFF
--- a/lib/pages/pool/AddLiquidity/AddLiquidity.dart
+++ b/lib/pages/pool/AddLiquidity/AddLiquidity.dart
@@ -129,6 +129,8 @@ class _AddLiquidityState extends State<AddLiquidity> {
                         }
                       }
                       bloc.add(PageRefreshEvent());
+                      _tokenAmountOneController.clear();
+                      _tokenAmountTwoController.clear();
                       setState(() {
                         Navigator.pop(context);
                       });
@@ -250,7 +252,6 @@ class _AddLiquidityState extends State<AddLiquidity> {
                       height: 40,
                       decoration: decor,
                       child: TextButton(
-                        // onPressed: (){},
                         onPressed: () => showDialog(
                           context: context,
                           builder: (BuildContext context) => AthleteTokenList(
@@ -295,7 +296,9 @@ class _AddLiquidityState extends State<AddLiquidity> {
                               child: TextButton(
                                   onPressed: () {
                                     _tokenAmountOneController.text = balance0;
-                                    onTokenInputChange(tknNum, balance0);
+                                    if (state.status == BlocStatus.success) {
+                                      onTokenInputChange(tknNum, balance0);
+                                    }
                                   },
                                   child: Text("MAX",
                                       style: textStyle(
@@ -309,7 +312,9 @@ class _AddLiquidityState extends State<AddLiquidity> {
                             child: TextFormField(
                               controller: tokenAmountController,
                               onChanged: (tokenInput) {
-                                onTokenInputChange(tknNum, tokenInput);
+                                if (state.status == BlocStatus.success) {
+                                  onTokenInputChange(tknNum, tokenInput);
+                                }
                               },
                               style: textStyle(Colors.grey[400]!, 22, false),
                               decoration: InputDecoration(
@@ -359,7 +364,6 @@ class _AddLiquidityState extends State<AddLiquidity> {
             height: 50,
             padding: EdgeInsets.all(10),
             verticalOffset: -60,
-            // preferBelow: false,
             decoration: BoxDecoration(
                 color: Colors.grey[800],
                 borderRadius: BorderRadius.circular(25)),
@@ -514,7 +518,6 @@ class _AddLiquidityState extends State<AddLiquidity> {
                     ],
                   ),
                 ),
-                // addLiquidityToolTip(elementWdt),
                 showYouReceived(poolInfo.recieveAmount),
                 ApproveButton(
                     elementWdt * 0.95,
@@ -555,6 +558,9 @@ class _AddLiquidityState extends State<AddLiquidity> {
                   )),
                   // Bottom Token container
                   createTokenButton(2, elementWdt, _tokenAmountTwoController),
+                  if (state.status == BlocStatus.no_data) ...[
+                    Text('Not Created - Please input both token amounts'),
+                  ]
                 ],
               ),
             ),

--- a/lib/pages/pool/AddLiquidity/bloc/PoolBloc.dart
+++ b/lib/pages/pool/AddLiquidity/bloc/PoolBloc.dart
@@ -61,7 +61,7 @@ class PoolBloc extends Bloc<PoolEvent, PoolState> {
         final errorMsg = response.getRight().toNullable()!.errorMsg;
         //TODO Create User facing error messages https://athletex.atlassian.net/browse/AX-466
         print(errorMsg);
-        emit(state.copyWith(status: BlocStatus.error));
+        emit(state.copyWith(status: BlocStatus.no_data, poolPairInfo: PoolPairInfo.empty()));
       }
     } catch (e) {
       emit(state.copyWith(status: BlocStatus.error));


### PR DESCRIPTION

# Description
If the user selects two tokens and the pair does not exist for them, then display a message notifying the user that they have to input both token amounts

Fixes Jira Ticket # 543
https://athletex.atlassian.net/browse/AX-543

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Is this a UI Change? If so please include screenshot of before and after states below
## Before
![image](https://user-images.githubusercontent.com/89420193/170766101-274ec351-08f0-4dc7-8e6b-11af83f64f3e.png)
![image](https://user-images.githubusercontent.com/89420193/170766126-2510f0e3-c3c1-443b-a444-b5bd0ee6a8b0.png)

## After
![image](https://user-images.githubusercontent.com/89420193/170766150-e5743b07-da97-4f3e-8f06-8ca7b6a8e3a5.png)
![image](https://user-images.githubusercontent.com/89420193/170766188-8bf5ff34-9dce-4c5a-ae26-7bc7fcc01872.png)

# How Has This Been Tested?
Ran the app on Chrome using the web-server

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have assigned 2 reviewers to check my work
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
