### PR TITLE
no-jira: temp switch to back up server address

### DIFF
--- a/lib/service/Api/MLBAthleteAPI.dart
+++ b/lib/service/Api/MLBAthleteAPI.dart
@@ -6,7 +6,7 @@ import 'package:retrofit/http.dart';
 
 part 'MLBAthleteAPI.g.dart';
 
-@RestApi(baseUrl: "https://db.athletex.io/mlb")
+@RestApi(baseUrl: "http://db.athletex.io:8080/mlb")
 abstract class MLBAthleteAPI {
   factory MLBAthleteAPI(Dio dio, {String baseUrl}) = _MLBAthleteAPI;
 

--- a/lib/service/Api/MLBAthleteAPI.g.dart
+++ b/lib/service/Api/MLBAthleteAPI.g.dart
@@ -10,7 +10,7 @@ part of 'MLBAthleteAPI.dart';
 
 class _MLBAthleteAPI implements MLBAthleteAPI {
   _MLBAthleteAPI(this._dio, {this.baseUrl}) {
-    baseUrl ??= 'https://db.athletex.io/mlb';
+    baseUrl ??= 'http://db.athletex.io:8080/mlb';
   }
 
   final Dio _dio;

--- a/lib/service/AthleteApi.dart
+++ b/lib/service/AthleteApi.dart
@@ -4,7 +4,7 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 
 class AthleteApi {
-  static final String _baseURL = 'https://db.athletex.io';
+  static final String _baseURL = 'http://db.athletex.io:8080';
   // static final String _baseURL = 'http://139.99.74.201:8080';
 
   static final int mStaffordId = 9038;


### PR DESCRIPTION
Since our server went down, we have to switch to aws and after 12 hours to get it set up to switch this is the best I can do for a temp fix.