### PR TITLE
[Mobile] - Pool - Info icons not functioning when user taps on them

### DIFF
--- a/lib/pages/pool/AddLiquidity/AddLiquidity.dart
+++ b/lib/pages/pool/AddLiquidity/AddLiquidity.dart
@@ -365,10 +365,10 @@ class _AddLiquidityState extends State<AddLiquidity> {
 
         Widget addLiquidityToolTip(double elementWdt) {
           return Tooltip(
+            triggerMode: TooltipTriggerMode.tap,
             height: 50,
             padding: EdgeInsets.all(10),
             verticalOffset: -100,
-            // preferBelow: false,
             decoration: BoxDecoration(
                 color: Colors.grey[800],
                 borderRadius: BorderRadius.circular(25)),
@@ -383,6 +383,7 @@ class _AddLiquidityState extends State<AddLiquidity> {
 
         Widget youWillReceiveToolTip() {
           return Tooltip(
+            triggerMode: TooltipTriggerMode.tap,
             height: 50,
             padding: EdgeInsets.all(10),
             verticalOffset: -60,


### PR DESCRIPTION
# Description
Ensure that the user can tap on the tooltip for the mobile version

Fixes Jira Ticket # 632
https://athletex.atlassian.net/browse/AX-632

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Is this a UI Change? If so please include screenshot of before and after states below
No

# How Has This Been Tested?
Ran the app on chrome using web server and ran the app using a mobile device

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have assigned 2 reviewers to check my work
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
