### PR TITLE
fix: handle `MetaMask` unavailable when connecting wallet on farm page

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,6 +10,23 @@
             "name": "Flutter: chrome",
             "url": "http://localhost:4001",
             "webRoot": "${workspaceFolder}"
+        },
+        {
+            "name": "ax_dapp",
+            "request": "launch",
+            "type": "dart"
+        },
+        {
+            "name": "ax_dapp (profile mode)",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "profile"
+        },
+        {
+            "name": "ax_dapp (release mode)",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "release"
         }
     ]
 }

--- a/lib/service/Controller/Controller.dart
+++ b/lib/service/Controller/Controller.dart
@@ -1,14 +1,14 @@
 // ignore_for_file: implementation_imports, avoid_web_libraries_in_flutter, invalid_use_of_internal_member
 
 import 'package:ax_dapp/service/Controller/createWallet/abstractWallet.dart';
+import 'package:get/get.dart';
+import 'package:http/http.dart';
+import 'package:url_launcher/url_launcher.dart';
+import 'package:web3dart/web3dart.dart';
 
 import './createWallet/createWallet.dart'
     if (dart.library.io) './createWallet/mobile.dart'
     if (dart.library.js) './createWallet/web.dart';
-import 'package:http/http.dart';
-import 'package:url_launcher/url_launcher.dart';
-import 'package:web3dart/web3dart.dart';
-import 'package:get/get.dart';
 
 //Comment this for Android
 const EMPTY_WALLET_ID = "0x0000000000000000000000000000000000000000";
@@ -52,12 +52,18 @@ class Controller extends GetxController {
   Future<int> connect() async {
     //Setting up Client & Credentials for connecting to dApp from a client
     DappWallet web3 = newWallet();
-
-    //Connect and setup credentials
-    await web3.connect().then((value) {
-      print("Connecting Wallet... ${web3.publicAddress}");
+    try {
+      //Connect and setup credentials
+      await web3.connect();
+      final publicAddress = web3.publicAddress;
+      print("Connecting Wallet... $publicAddress");
+      if (publicAddress == null) {
+        throw const MetaMaskUnavailableFailure();
+      }
       this.publicAddress.value = web3.publicAddress;
-    });
+    } catch (_) {
+      return -1;
+    }
 
     try {
       networkID.value = web3.networkID;

--- a/lib/service/Controller/createWallet/abstractWallet.dart
+++ b/lib/service/Controller/createWallet/abstractWallet.dart
@@ -1,5 +1,10 @@
 import 'createWallet.dart';
 
+/// Thrown when MetaMask extension is not installed.
+class MetaMaskUnavailableFailure implements Exception {
+  const MetaMaskUnavailableFailure();
+}
+
 abstract class DappWallet {
   static DappWallet? _connectedWalletInstance;
   var activeChainId;

--- a/lib/service/Controller/createWallet/web.dart
+++ b/lib/service/Controller/createWallet/web.dart
@@ -1,12 +1,14 @@
 // ignore_for_file: avoid_web_libraries_in_flutter
 
 import 'dart:html';
+
 import 'package:erc20/erc20.dart';
-import 'package:http/http.dart';
-import 'package:web3dart/web3dart.dart' as Web3Dart;
-import 'abstractWallet.dart';
 import 'package:flutter_web3/flutter_web3.dart' as FlutterWeb3;
+import 'package:http/http.dart';
 import 'package:web3_browser/web3_browser.dart';
+import 'package:web3dart/web3dart.dart' as Web3Dart;
+
+import 'abstractWallet.dart';
 
 DappWallet newWallet() => WebWallet();
 
@@ -31,6 +33,7 @@ class WebWallet extends DappWallet {
           "[Console] This is the credentials type: ${this.credentials.toString()}");
     } else {
       print("[Console] Ethereum is not supproted. Please install MetaMask.");
+      throw const MetaMaskUnavailableFailure();
     }
   }
 

--- a/lib/service/Dialog.dart
+++ b/lib/service/Dialog.dart
@@ -274,7 +274,8 @@ Dialog walletDialog(BuildContext context) {
                 boxDecoration(Colors.transparent, 100, 2, Colors.grey[400]!),
             child: TextButton(
               onPressed: () {
-                Navigator.push(context, MaterialPageRoute(builder: (context) => MobileLoginPage()));
+                Navigator.push(context,
+                    MaterialPageRoute(builder: (context) => MobileLoginPage()));
               },
               child: Text(
                 "Add/Create wallet",
@@ -1249,7 +1250,7 @@ Dialog yourAXDialog(BuildContext context) {
                                   },
                                   child: Text("Buy AX",
                                       style:
-                                          textStyle(Colors.black, 14, true)))),                                                
+                                          textStyle(Colors.black, 14, true)))),
                         ])),
               ])))));
 }


### PR DESCRIPTION
# Description
Grey portions appearing on farm page when user tries to connect `MetaMask` without having the extension installed.
I wasn't able to reproduce this issue locally, however there were unhandled scenarios surrounding `MetaMask` and wallet connect.

- fix: handle `MetaMask` unavailable on wallet connect
- fix: show `MetaMask` connect dialog when the extension is not installed

Fixes Jira Ticket: https://athletex.atlassian.net/browse/AX-652

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
- tested locally following the reproducible steps in the task

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have assigned 2 reviewers to check my work
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
