### PR TITLE
[High] - [Mobile] Scout - In Mobile user can't scroll horizontally to see all the dates and amounts in graph

### DIFF
--- a/lib/pages/athlete/AthletePage.dart
+++ b/lib/pages/athlete/AthletePage.dart
@@ -59,10 +59,7 @@ class _AthletePageState extends State<AthletePage> {
     final LSPController lspController = Get.find();
     lspController.updateAptAddress(athlete.id);
     print(athlete.id);
-    _zoomPanBehavior = ZoomPanBehavior(
-      enableMouseWheelZooming: true,
-      enablePanning: true,
-    );
+    _zoomPanBehavior = ZoomPanBehavior(enableMouseWheelZooming: true, enablePanning: true, enablePinching: true);
     _longToolTipBehavior = TooltipBehavior(enable: true);
     _shortToolTipBehavior = TooltipBehavior(enable: true);
   }

--- a/lib/pages/athlete/components/BuildLongChart.dart
+++ b/lib/pages/athlete/components/BuildLongChart.dart
@@ -6,7 +6,7 @@ import 'package:syncfusion_flutter_charts/charts.dart';
 SfCartesianChart buildLongChart(List<GraphData> chartStats, TooltipBehavior _longToolTipBehavior, ZoomPanBehavior _zoomPanBehavior) {
     return SfCartesianChart(
       tooltipBehavior: _longToolTipBehavior,
-      legend: Legend(isVisible: true),
+      legend: Legend(isVisible: false),
       zoomPanBehavior: _zoomPanBehavior,
       enableSideBySideSeriesPlacement: true,
       series: <FastLineSeries>[

--- a/lib/pages/athlete/components/BuildShortChart.dart
+++ b/lib/pages/athlete/components/BuildShortChart.dart
@@ -8,7 +8,7 @@ SfCartesianChart buildShortChart(List<GraphData> chartStats, TooltipBehavior _sh
       tooltipBehavior: _shortToolTipBehavior,
       zoomPanBehavior: _zoomPanBehavior,
       enableSideBySideSeriesPlacement: true,
-      legend: Legend(isVisible: true),
+      legend: Legend(isVisible: false),
       series: <FastLineSeries>[
         FastLineSeries<GraphData, DateTime>(
           name: 'Price',


### PR DESCRIPTION
# Description
Needed to fix an issue where the user cannot zoom in on the graph or pan the graph in mobile. I had to enable pinch zooming for mobile devices so that we can zoom in on the graph.

Fixes Jira Ticket # https://athletex.atlassian.net/browse/AX-695

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Is this a UI Change? If so please include screenshot of before and after states below
No, this is more of a behavioral issue with the mobile version

# How Has This Been Tested?
Ran the app on chrome using web-server

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have assigned 2 reviewers to check my work
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
