### PR TITLE
bug/AX-623 add dialog for errors

### DIFF
--- a/lib/service/ApproveButton.dart
+++ b/lib/service/ApproveButton.dart
@@ -1,3 +1,4 @@
+import 'package:ax_dapp/service/dialog.dart';
 import 'package:flutter/material.dart';
 
 // This code changes the state of the button
@@ -79,7 +80,13 @@ class _ApproveButtonState extends State<ApproveButton> {
               showDialog(
                   context: context,
                   builder: (BuildContext context) =>
-                      widget.confirmDialog(context));
+                    widget.confirmDialog(context),
+              );
+            }).catchError((error) {
+              showDialog(
+                context: context,
+                builder: (context) => FailedDialog(),
+              );
             });
           } else {
             //Approve button was pressed

--- a/lib/service/Controller/Controller.dart
+++ b/lib/service/Controller/Controller.dart
@@ -51,7 +51,7 @@ class Controller extends GetxController {
 
   Future<int> connect() async {
     //Setting up Client & Credentials for connecting to dApp from a client
-    DappWallet web3 = newWallet();
+    DappWallet web3 = newWallet() as DappWallet;
     try {
       //Connect and setup credentials
       await web3.connect();

--- a/lib/service/Controller/Swap/SwapController.dart
+++ b/lib/service/Controller/Swap/SwapController.dart
@@ -90,11 +90,14 @@ class SwapController extends GetxController {
       txString = await _aptRouter.swapExactTokensForTokens(
           tokenAAmount, amountOutMin, path, to, deadline.value,
           credentials: controller.credentials);
+      controller.updateTxString(txString);
     } catch (e) {
+      txString = "";
+      controller.updateTxString(txString);
       print(
           "[Console] Unable to swap [$tokenAAddress, $tokenBAddress] tokens \n $e");
+      return Future.error(e);
     }
-    controller.updateTxString(txString);
   }
 
   Future<void> createPair() async {


### PR DESCRIPTION
# Description

[High] Scout - User is getting success popup after approve a Sell even if they don't have sufficient fund in wallet

- I tried to test as many user paths as I could but I am still not sure if I missed some.

- I don't believe refactoring is a good action during this ticket 
(e.g. how dialogs are created/code duplications related to this/layering of architecture with regards to responsibilities of different components); 
A separate issue in jira should be created for each item required.

- The general usage of ApproveButton across the app may have the same issue - lack of error handling (Buy/ Sell/ Stake/ Unstake/ AddLiquidity/ MyLiquidity/ Mint/ Trade/...) I suspect these have a similar issues in similar use cases. 
Some of these have been touched by this PR but I am unsure in what percentage.
I will notify QA to take a closer look and open tickets accordingly after this PR gets approved.

- when the wallet was not connected; the current behaviour still hasn't got the best UX but it is a step forward in my opinion.

- I didn't know if there is any UI asset for the error dialog so I created a simple reusable one.

Fixes Jira Ticket # 
https://athletex.atlassian.net/browse/AX-623

## Type of change
Please delete options that are not relevant.
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Is this a UI Change? If so please include screenshot of before and after states below

<img width="551" alt="Screenshot 2022-07-19 at 17 49 34" src="https://user-images.githubusercontent.com/1089865/179795784-80687b8b-e6da-410e-a846-bdba1fa782b2.png">

<img width="1678" alt="Screenshot 2022-07-19 at 18 57 37" src="https://user-images.githubusercontent.com/1089865/179795792-89ae14aa-252d-4b81-8a67-31a993b3435a.png">



# How Has This Been Tested?
- as described in the ticket.
- in cases where I noticed the "Approve button" being used.
- some alternate paths I could think of (closing /rejecting before the actual fail...).


# Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have assigned 2 reviewers to check my work
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
