### PR TITLE
AX-623 Dialog for failed operation

### DIFF
--- a/lib/service/approve_button.dart
+++ b/lib/service/approve_button.dart
@@ -1,3 +1,4 @@
+import 'package:ax_dapp/service/dialog.dart';
 import 'package:flutter/material.dart';
 
 // This code changes the state of the button
@@ -85,6 +86,11 @@ class _ApproveButtonState extends State<ApproveButton> {
                 context: context,
                 builder: (BuildContext context) =>
                     widget.confirmDialog(context),
+              );
+            }).catchError((error) {
+              showDialog<void>(
+                context: context,
+                builder: (context) => const FailedDialog(),
               );
             });
           } else {

--- a/lib/service/controller/swap/swap_controller.dart
+++ b/lib/service/controller/swap/swap_controller.dart
@@ -95,8 +95,12 @@ class SwapController extends GetxController {
         deadline.value,
         credentials: controller.credentials,
       );
-    } catch (_) {}
-    controller.updateTxString(txString);
+      controller.updateTxString(txString);
+    } catch (e) {
+      txString = '';
+      controller.updateTxString(txString);
+      return Future.error(e);
+    }
   }
 
   Future<void> createPair() async {

--- a/lib/service/dialog.dart
+++ b/lib/service/dialog.dart
@@ -2010,3 +2010,75 @@ BoxDecoration boxDecoration(
     border: Border.all(color: borCol, width: borWid),
   );
 }
+
+class FailedDialog extends StatelessWidget {
+  const FailedDialog({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final _height = MediaQuery.of(context).size.height;
+    final _width = MediaQuery.of(context).size.width;
+    var wid = 500.0;
+    const edge = 40.0;
+    if (_width < 505) wid = _width;
+    var hgt = 335.0;
+    if (_height < 340) hgt = _height;
+
+    return Dialog(
+      backgroundColor: Colors.transparent,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Container(
+        height: hgt,
+        width: wid,
+        decoration: boxDecoration(Colors.grey[900]!, 30, 0, Colors.black),
+        child: Center(
+          child: SizedBox(
+            height: 275,
+            width: wid - edge,
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: <Widget>[
+                SizedBox(
+                  width: wid - edge,
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: <Widget>[
+                      Container(width: 5),
+                      Text(
+                        'Something went wrong',
+                        style: textStyle(Colors.white, 20, false),
+                      ),
+                      SizedBox(
+                        width: 40,
+                        child: IconButton(
+                          icon: const Icon(
+                            Icons.close,
+                            color: Colors.white,
+                          ),
+                          onPressed: () => Navigator.pop(context),
+                        ),
+                      )
+                    ],
+                  ),
+                ),
+                Expanded(
+                  child: Center(
+                    child: Icon(
+                      Icons.cancel_outlined,
+                      size: 150,
+                      color: Colors.amber[400],
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
# Description

[High] Scout - User is getting success popup after approve a Sell even if they don't have sufficient fund in wallet

- I tried to test as many user paths as I could but I am still not sure if I missed some.

- I don't believe refactoring is a good action during this ticket 
(e.g. how dialogs are created/code duplications related to this/layering of architecture with regards to responsibilities of different components); 
A separate issue in jira should be created for each item required.

- The general usage of ApproveButton across the app may have the same issue - lack of error handling (Buy/ Sell/ Stake/ Unstake/ AddLiquidity/ MyLiquidity/ Mint/ Trade/...) I suspect these have a similar issues in similar use cases. 
Some of these have been touched by this PR but I am unsure in what percentage.
I will notify QA to take a closer look and open tickets accordingly after this PR gets approved.

- when the wallet was not connected; the current behaviour still hasn't got the best UX but it is a step forward in my opinion.

- I didn't know if there is any UI asset for the error dialog so I created a simple reusable one.

Fixes Jira Ticket # 
https://athletex.atlassian.net/browse/AX-623

## Type of change
Please delete options that are not relevant.
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Is this a UI Change? If so please include screenshot of before and after states below

<img width="1678" alt="Screenshot 2022-07-19 at 18 57 37" src="https://user-images.githubusercontent.com/1089865/179799446-be7e5a0d-e0d5-4422-b93e-b52607bfb7d0.png">

<img width="1674" alt="Screenshot 2022-07-19 at 18 58 09" src="https://user-images.githubusercontent.com/1089865/179799155-6aa6a06d-f45c-4946-8feb-e4c496f4b48a.png">



# How Has This Been Tested?
- as described in the ticket.
- in cases where I noticed the "Approve button" being used.
- some alternate paths I could think of (closing /rejecting before the actual fail...).


# Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have assigned 2 reviewers to check my work
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
