### PR TITLE
AX-677on successful confirm remove redeem dialog

### DIFF
--- a/lib/pages/scout/dialogs/redeem_dialog.dart
+++ b/lib/pages/scout/dialogs/redeem_dialog.dart
@@ -407,7 +407,10 @@ class _RedeemDialogState extends State<RedeemDialog> {
                             context: context,
                             builder: (BuildContext context) =>
                                 confirmTransaction(context, true, ''),
-                          ).then((value) => Navigator.pop(context));
+                          );
+                          if(mounted){
+                            Navigator.pop(context);
+                          }
                         }
                       },
                       child: Text(

--- a/lib/pages/scout/dialogs/redeem_dialog.dart
+++ b/lib/pages/scout/dialogs/redeem_dialog.dart
@@ -407,7 +407,7 @@ class _RedeemDialogState extends State<RedeemDialog> {
                             context: context,
                             builder: (BuildContext context) =>
                                 confirmTransaction(context, true, ''),
-                          );
+                          ).then((value) => Navigator.pop(context));
                         }
                       },
                       child: Text(


### PR DESCRIPTION
# Description
Before
previously this was what ticket was for [High] - Scout - Redeem: Appearance of success popup before approving operation in metamask.

but this is working correctly and we only need one confirm once not twic. But we needed to remove the redeem dialog once the transaction confirmed


Fixes Jira Ticket #  https://athletex.atlassian.net/browse/AX-677

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Is this a UI Change? If so please include screenshot of before and after states below

# How Has This Been Tested?
tested to make sure the redeem dialog is dismissed

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have assigned 2 reviewers to check my work
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
