### PR TITLE
[AX 762] - Farm - Some information of farm cards are hiding under footer and user can't see them upon scrolling 

### DIFF
--- a/lib/pages/farm/desktop_farm.dart
+++ b/lib/pages/farm/desktop_farm.dart
@@ -125,7 +125,7 @@ class _DesktopFarmState extends State<DesktopFarm> {
             SizedBox(
               //contains list of allfarms cards
               width: layoutWdt,
-              height: layoutHgt,
+              height: layoutHgt - 120,
               child: ScrollConfiguration(
                 behavior: ScrollConfiguration.of(context).copyWith(
                   dragDevices: {


### PR DESCRIPTION
# Description
This ticket addresses the issue where the contents on the farm page are cut off when the user scrolls to the bottom. This ticket fixes the issue

Fixes Jira Ticket # https://athletex.atlassian.net/browse/AX-762

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Is this a UI Change? If so please include screenshot of before and after states below
## Before
![image](https://user-images.githubusercontent.com/89420193/180124830-c0b1e694-9f80-451c-ba47-f89bfe54e9b6.png)

## After
![image](https://user-images.githubusercontent.com/89420193/180124861-5cb4f89f-5560-4c24-826d-66a8100fd0f3.png)

# How Has This Been Tested?
Ran the app on chrome using web-server

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have assigned 2 reviewers to check my work
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
