### PR TITLE
[AX - 779] - [High] Scout - "You Receive" not clearing in Mint Pair if user closes popup or change tabs

### DIFF
--- a/lib/pages/scout/dialogs/mint_dialog.dart
+++ b/lib/pages/scout/dialogs/mint_dialog.dart
@@ -377,6 +377,7 @@ class _MintDialogState extends State<MintDialog> {
   void dispose() {
     // Clean up the controller when the widget is removed from the widget tree.
     // This also removes the _printLatestValue listener.
+    lspController.createAmt(0);
     _aptAmountController.dispose();
     super.dispose();
   }


### PR DESCRIPTION
# Description
You receive field on the mint dialog will now clear when the user exits the popup

Fixes Jira Ticket # https://athletex.atlassian.net/browse/AX-779

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Is this a UI Change? If so please include screenshot of before and after states below

# How Has This Been Tested?
Ran the app on Chrome using web-server

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have assigned 2 reviewers to check my work
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
