### PR TITLE
no-jira: override web3 dependencies for compatibility with firebase/flutter_test

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -30,7 +30,7 @@ packages:
     source: hosted
     version: "2.3.1"
   async:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       name: async
       url: "https://pub.dartlang.org"
@@ -148,6 +148,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.0"
+  charcode:
+    dependency: transitive
+    description:
+      name: charcode
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.3.1"
   chart_sparkline:
     dependency: "direct main"
     description:
@@ -182,7 +189,7 @@ packages:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.0"
   code_builder:
     dependency: transitive
     description:
@@ -259,7 +266,7 @@ packages:
       name: coverage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.0"
+    version: "1.3.2"
   crypto:
     dependency: transitive
     description:
@@ -323,6 +330,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.0"
+  fake_async:
+    dependency: transitive
+    description:
+      name: fake_async
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.3.0"
   ffi:
     dependency: transitive
     description:
@@ -343,7 +357,7 @@ packages:
       name: firebase_analytics
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "9.1.11"
+    version: "9.3.0"
   firebase_analytics_platform_interface:
     dependency: transitive
     description:
@@ -352,35 +366,33 @@ packages:
     source: hosted
     version: "3.3.0"
   firebase_analytics_web:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
-      path: "packages/firebase_analytics/firebase_analytics_web"
-      ref: "firebase_analytics_web-0.4.0+16-fix-for-web"
-      resolved-ref: "56e16a3076a3b74246071bb3cb05b5933fd522df"
-      url: "https://github.com/durduman/flutterfire.git"
-    source: git
-    version: "0.4.0+16"
+      name: firebase_analytics_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.4.2"
   firebase_core:
     dependency: "direct main"
     description:
       name: firebase_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.19.0"
+    version: "1.20.0"
   firebase_core_platform_interface:
     dependency: transitive
     description:
       name: firebase_core_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.4.1"
+    version: "4.5.0"
   firebase_core_web:
     dependency: transitive
     description:
       name: firebase_core_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.5"
+    version: "1.7.1"
   fixnum:
     dependency: transitive
     description:
@@ -442,6 +454,11 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.0"
+  flutter_test:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_web3:
     dependency: "direct main"
     description:
@@ -691,7 +708,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.12"
+    version: "0.12.11"
   material_color_utilities:
     dependency: transitive
     description:
@@ -761,7 +778,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.1"
   path_provider:
     dependency: transitive
     description:
@@ -1067,7 +1084,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.0"
+    version: "1.8.2"
   stack_trace:
     dependency: transitive
     description:
@@ -1095,7 +1112,7 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.0"
   syncfusion_flutter_charts:
     dependency: "direct main"
     description:
@@ -1116,28 +1133,28 @@ packages:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.0"
   test:
     dependency: "direct dev"
     description:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.21.4"
+    version: "1.21.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.12"
+    version: "0.4.9"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.16"
+    version: "0.4.13"
   timing:
     dependency: transitive
     description:
@@ -1270,7 +1287,7 @@ packages:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "9.0.0"
+    version: "8.3.0"
   vxstate:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,8 +32,8 @@ dependencies:
   dio: ^4.0.6
   equatable: ^2.0.3
   erc20: ^1.0.0
-  firebase_analytics: ^9.1.11
-  firebase_core: ^1.19.0
+  firebase_analytics: ^9.3.0
+  firebase_core: ^1.20.0
   fl_chart: ^0.55.0
   flutter:
     sdk: flutter
@@ -69,18 +69,15 @@ dependencies:
   webfeed: ^0.7.0
 
 dependency_overrides:
-  firebase_analytics_web:
-    git: 
-      url: https://github.com/durduman/flutterfire.git
-      path: packages/firebase_analytics/firebase_analytics_web
-      ref: firebase_analytics_web-0.4.0+16-fix-for-web
+  web3dart: ^2.4.1
+  async: ^2.9.0
 
 dev_dependencies:
   build_runner: ^2.2.0
   json_serializable: ^6.3.1
   mockito: ^5.2.0
   retrofit_generator: ^4.0.2
-  test: ^1.21.4
+  test:
   very_good_analysis: ^3.0.1
 
 # For information on the generic Dart part of this file, see the


### PR DESCRIPTION
# Description
 Current @durduman 's flutter_fire dependency override is causing multiple developers on the team issues with building. After researching alternative options I found that we could choose to override the web3 package instead. 
 I am not sure if this is could cause problems so I would like some input on the risk from the team otherwise I think this will unblock a lot of devs

~~Fixes Jira Ticket~~ No Jira

## Type of change
Please delete options that are not relevant.
- [X] Bug fix (non-breaking change which fixes an issue)



# How Has This Been Tested?
Run `flutter clean`
Then `flutter pub get`

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have assigned 2 reviewers to check my work
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
