### PR TITLE
[AX-858] - Stake balance error

### DIFF
--- a/lib/pages/farm/dialogs/stake_dialog.dart
+++ b/lib/pages/farm/dialogs/stake_dialog.dart
@@ -140,7 +140,7 @@ class _StakeDialogState extends State<StakeDialog> {
                                   selectedFarm.stakedInfo.value.viewAmount,
                                 ) +
                                 double.parse(selectedFarm.strStakeInput.value);
-                            isValid.value = true;
+                            isValid.value = checkValidInput(selectedFarm);
                           },
                           child: Text(
                             'Max',
@@ -164,14 +164,7 @@ class _StakeDialogState extends State<StakeDialog> {
                                 double.parse(selectedFarm.strStakeInput.value);
                             selectedFarm.strStakeInput.value =
                                 double.parse(value).toString();
-                            if (double.parse(selectedFarm.strStakeInput.value) >
-                                double.parse(
-                                  selectedFarm.stakingInfo.value.viewAmount,
-                                )) {
-                              isValid.value = false;
-                            } else {
-                              isValid.value = true;
-                            }
+                            isValid.value = checkValidInput(selectedFarm);
                           },
                           style: textStyle(Colors.grey[400]!, 22, false),
                           decoration: InputDecoration(
@@ -289,4 +282,8 @@ class _StakeDialogState extends State<StakeDialog> {
       ),
     );
   }
+
+  bool checkValidInput(FarmController selectedFarm) =>
+      !(double.parse(selectedFarm.strStakeInput.value) >
+          double.parse(selectedFarm.stakingInfo.value.viewAmount));
 }

--- a/lib/pages/farm/dialogs/stake_dialog.dart
+++ b/lib/pages/farm/dialogs/stake_dialog.dart
@@ -169,6 +169,8 @@ class _StakeDialogState extends State<StakeDialog> {
                                   selectedFarm.stakingInfo.value.viewAmount,
                                 )) {
                               isValid.value = false;
+                            } else {
+                              isValid.value = true;
                             }
                           },
                           style: textStyle(Colors.grey[400]!, 22, false),

--- a/lib/pages/farm/dialogs/stake_dialog.dart
+++ b/lib/pages/farm/dialogs/stake_dialog.dart
@@ -132,14 +132,10 @@ class _StakeDialogState extends State<StakeDialog> {
                         ),
                         child: TextButton(
                           onPressed: () {
-                            stakeAxInput.text =
-                                selectedFarm.stakingInfo.value.viewAmount;
-                            selectedFarm.strStakeInput.value =
-                                stakeAxInput.text;
-                            totalStakedBalance.value = double.parse(
-                                  selectedFarm.stakedInfo.value.viewAmount,
-                                ) +
-                                double.parse(selectedFarm.strStakeInput.value);
+                            getMaxBalanceInput(
+                              selectedFarm,
+                              totalStakedBalance,
+                            );
                             isValid.value = checkValidInput(selectedFarm);
                           },
                           child: Text(
@@ -153,17 +149,7 @@ class _StakeDialogState extends State<StakeDialog> {
                         child: TextFormField(
                           controller: stakeAxInput,
                           onChanged: (value) {
-                            if (value.isEmpty) {
-                              totalStakedBalance.value = 0.0;
-                              isValid.value = true;
-                            }
-                            selectedFarm.strStakeInput.value = value;
-                            totalStakedBalance.value = double.parse(
-                                  selectedFarm.stakedInfo.value.viewAmount,
-                                ) +
-                                double.parse(selectedFarm.strStakeInput.value);
-                            selectedFarm.strStakeInput.value =
-                                double.parse(value).toString();
+                            stakeInput(value, totalStakedBalance, selectedFarm);
                             isValid.value = checkValidInput(selectedFarm);
                           },
                           style: textStyle(Colors.grey[400]!, 22, false),
@@ -281,6 +267,35 @@ class _StakeDialogState extends State<StakeDialog> {
         ),
       ),
     );
+  }
+
+  void stakeInput(
+    String value,
+    RxDouble totalStakedBalance,
+    FarmController selectedFarm,
+  ) {
+    if (value.isEmpty) {
+      totalStakedBalance.value = 0.0;
+      isValid.value = true;
+    }
+    selectedFarm.strStakeInput.value = value;
+    totalStakedBalance.value = double.parse(
+          selectedFarm.stakedInfo.value.viewAmount,
+        ) +
+        double.parse(selectedFarm.strStakeInput.value);
+    selectedFarm.strStakeInput.value = double.parse(value).toString();
+  }
+
+  void getMaxBalanceInput(
+    FarmController selectedFarm,
+    RxDouble totalStakedBalance,
+  ) {
+    stakeAxInput.text = selectedFarm.stakingInfo.value.viewAmount;
+    selectedFarm.strStakeInput.value = stakeAxInput.text;
+    totalStakedBalance.value = double.parse(
+          selectedFarm.stakedInfo.value.viewAmount,
+        ) +
+        double.parse(selectedFarm.strStakeInput.value);
   }
 
   bool checkValidInput(FarmController selectedFarm) =>

--- a/lib/pages/farm/dialogs/unstake_dialog.dart
+++ b/lib/pages/farm/dialogs/unstake_dialog.dart
@@ -128,17 +128,10 @@ class _UnstakeDialogState extends State<UnstakeDialog> {
                         ),
                         child: TextButton(
                           onPressed: () {
-                            unStakeAxInput.text =
-                                selectedFarm.stakedInfo.value.viewAmount;
-                            selectedFarm.strUnStakeInput.value =
-                                unStakeAxInput.text;
-                            totalStakedBalance.value = double.parse(
-                                  selectedFarm.stakedInfo.value.viewAmount,
-                                ) -
-                                double.parse(
-                                  selectedFarm.strUnStakeInput.value,
-                                );
-                            isValid.value = !totalStakedBalance.isNegative;
+                            getMaxBalanceInput(
+                              selectedFarm,
+                              totalStakedBalance,
+                            );
                           },
                           child: Text(
                             'Max',
@@ -151,18 +144,11 @@ class _UnstakeDialogState extends State<UnstakeDialog> {
                         child: TextFormField(
                           controller: unStakeAxInput,
                           onChanged: (value) {
-                            if (value.isEmpty) {
-                              totalStakedBalance.value = 0.0;
-                              isValid.value = true;
-                            }
-                            selectedFarm.strUnStakeInput.value = value;
-                            totalStakedBalance.value = double.parse(
-                                  selectedFarm.stakedInfo.value.viewAmount,
-                                ) -
-                                double.parse(
-                                  selectedFarm.strUnStakeInput.value,
-                                );
-                            isValid.value = !totalStakedBalance.isNegative;
+                            unstakeInput(
+                              value,
+                              totalStakedBalance,
+                              selectedFarm,
+                            );
                           },
                           style: textStyle(Colors.grey[400]!, 22, false),
                           decoration: InputDecoration(
@@ -264,5 +250,39 @@ class _UnstakeDialogState extends State<UnstakeDialog> {
         ),
       ),
     );
+  }
+
+  void unstakeInput(
+    String value,
+    RxDouble totalStakedBalance,
+    FarmController selectedFarm,
+  ) {
+    if (value.isEmpty) {
+      totalStakedBalance.value = 0.0;
+      isValid.value = true;
+    }
+    selectedFarm.strUnStakeInput.value = value;
+    totalStakedBalance.value = double.parse(
+          selectedFarm.stakedInfo.value.viewAmount,
+        ) -
+        double.parse(
+          selectedFarm.strUnStakeInput.value,
+        );
+    isValid.value = !totalStakedBalance.isNegative;
+  }
+
+  void getMaxBalanceInput(
+    FarmController selectedFarm,
+    RxDouble totalStakedBalance,
+  ) {
+    unStakeAxInput.text = selectedFarm.stakedInfo.value.viewAmount;
+    selectedFarm.strUnStakeInput.value = unStakeAxInput.text;
+    totalStakedBalance.value = double.parse(
+          selectedFarm.stakedInfo.value.viewAmount,
+        ) -
+        double.parse(
+          selectedFarm.strUnStakeInput.value,
+        );
+    isValid.value = !totalStakedBalance.isNegative;
   }
 }

--- a/lib/util/insufficient_balance.dart
+++ b/lib/util/insufficient_balance.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+class InsufficientBalance extends StatelessWidget {
+  const InsufficientBalance({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 175,
+      height: 45,
+      decoration: BoxDecoration(
+        border: Border.all(color: Colors.amber),
+        color: Colors.transparent,
+        borderRadius: BorderRadius.circular(100),
+      ),
+      child: const TextButton(
+        onPressed: null,
+        child: Text(
+          'Insufficient Balance',
+          style: TextStyle(
+            fontSize: 16,
+            color: Colors.amber,
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
# Description
This ticket addresses the issue when the user inputs more than what they have in the balance. If this happens, we will show a message warning the user that they cannot make a transaction unless the input is valid

Fixes Jira Ticket # https://athletex.atlassian.net/browse/AX-858

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Is this a UI Change? If so please include screenshot of before and after states below
## Before
![image](https://user-images.githubusercontent.com/89420193/184152479-d26031d3-1100-42aa-9d8e-4e46bf2c24f4.png)

## After
![image](https://user-images.githubusercontent.com/89420193/184152681-5413e9f9-d2e0-4717-ab21-5909e5e646f4.png)

# How Has This Been Tested?
Ran the app on chrome using web-server and tested the stake dialog by inputting numbers

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have assigned 2 reviewers to check my work
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
