### PR TITLE
Display info text if search result is empty on farm page

### DIFF
--- a/lib/pages/farm/bloc/farm_bloc.dart
+++ b/lib/pages/farm/bloc/farm_bloc.dart
@@ -89,14 +89,14 @@ class FarmBloc extends Bloc<FarmEvent, FarmState> {
       state.copy(
         filteredFarms: state.farms
             .where(
-              (farm) => farm.strName
+              (farm) => (farm.getAthleteTokenName() ?? farm.strName)
                   .toUpperCase()
                   .contains(event.searchedName.toUpperCase()),
             )
             .toList(),
         filteredStakedFarms: state.stakedFarms
             .where(
-              (farm) => farm.strName
+              (farm) => (farm.getAthleteTokenName() ?? farm.strName)
                   .toUpperCase()
                   .contains(event.searchedName.toUpperCase()),
             )

--- a/lib/pages/farm/desktop_farm.dart
+++ b/lib/pages/farm/desktop_farm.dart
@@ -135,38 +135,44 @@ class _DesktopFarmState extends State<DesktopFarm> {
                 ),
                 child: state.status != BlocStatus.success
                     ? widget
-                    : GridView.builder(
-                        gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-                          crossAxisCount: isWeb ? 4 : 1,
-                          mainAxisSpacing: 5,
-                          crossAxisSpacing: 5,
-                          childAspectRatio: state.isAllFarms ? 1.75 : 1,
-                        ),
-                        padding: EdgeInsets.zero,
-                        physics: const BouncingScrollPhysics(),
-                        itemCount: isAllFarms
-                            ? state.filteredFarms.length
-                            : state.filteredStakedFarms.length,
-                        itemBuilder: (context, index) {
-                          return isAllFarms
-                              ? farmItem(
-                                  context,
-                                  isWeb,
-                                  FarmController(state.filteredFarms[index]),
-                                  listHeight,
-                                  layoutWdt,
-                                )
-                              : myFarmItem(
-                                  context,
-                                  isWeb,
-                                  FarmController(
-                                    state.filteredStakedFarms[index],
-                                  ),
-                                  listHeight,
-                                  layoutWdt,
-                                );
-                        },
-                      ),
+                    : (state.isAllFarms
+                            ? state.filteredFarms.isEmpty
+                            : state.filteredStakedFarms.isEmpty)
+                        ? noData()
+                        : GridView.builder(
+                            gridDelegate:
+                                SliverGridDelegateWithFixedCrossAxisCount(
+                              crossAxisCount: isWeb ? 4 : 1,
+                              mainAxisSpacing: 5,
+                              crossAxisSpacing: 5,
+                              childAspectRatio: state.isAllFarms ? 1.75 : 1,
+                            ),
+                            padding: EdgeInsets.zero,
+                            physics: const BouncingScrollPhysics(),
+                            itemCount: isAllFarms
+                                ? state.filteredFarms.length
+                                : state.filteredStakedFarms.length,
+                            itemBuilder: (context, index) {
+                              return isAllFarms
+                                  ? farmItem(
+                                      context,
+                                      isWeb,
+                                      FarmController(
+                                          state.filteredFarms[index]),
+                                      listHeight,
+                                      layoutWdt,
+                                    )
+                                  : myFarmItem(
+                                      context,
+                                      isWeb,
+                                      FarmController(
+                                        state.filteredStakedFarms[index],
+                                      ),
+                                      listHeight,
+                                      layoutWdt,
+                                    );
+                            },
+                          ),
               ),
             ),
           ],
@@ -258,7 +264,7 @@ class _DesktopFarmState extends State<DesktopFarm> {
         children: [
           const SizedBox(width: 8),
           const Icon(Icons.search, color: Colors.white),
-          const SizedBox(width: 50),
+          const SizedBox(width: 8),
           Expanded(
             child: TextFormField(
               controller: myController,

--- a/lib/pages/farm/desktop_farm.dart
+++ b/lib/pages/farm/desktop_farm.dart
@@ -158,7 +158,7 @@ class _DesktopFarmState extends State<DesktopFarm> {
                                       context,
                                       isWeb,
                                       FarmController(
-                                          state.filteredFarms[index]),
+                                          state.filteredFarms[index],),
                                       listHeight,
                                       layoutWdt,
                                     )

--- a/lib/pages/farm/desktop_farm.dart
+++ b/lib/pages/farm/desktop_farm.dart
@@ -158,7 +158,8 @@ class _DesktopFarmState extends State<DesktopFarm> {
                                       context,
                                       isWeb,
                                       FarmController(
-                                          state.filteredFarms[index],),
+                                        state.filteredFarms[index],
+                                      ),
                                       listHeight,
                                       layoutWdt,
                                     )

--- a/lib/pages/farm/models/farm_model.dart
+++ b/lib/pages/farm/models/farm_model.dart
@@ -1,6 +1,6 @@
-import 'package:json_annotation/json_annotation.dart';
 import 'package:ax_dapp/service/token_list.dart';
 import 'package:ax_dapp/util/supported_sports.dart';
+import 'package:json_annotation/json_annotation.dart';
 part 'farm_model.g.dart';
 
 @JsonSerializable()

--- a/lib/pages/farm/models/farm_model.dart
+++ b/lib/pages/farm/models/farm_model.dart
@@ -1,4 +1,6 @@
 import 'package:json_annotation/json_annotation.dart';
+import 'package:ax_dapp/service/token_list.dart';
+import 'package:ax_dapp/util/supported_sports.dart';
 part 'farm_model.g.dart';
 
 @JsonSerializable()
@@ -46,5 +48,21 @@ class FarmModel {
   @override
   String toString() {
     return '''APTFarmInfo(name: "$strName", address: "$strAddress", stakedAlias: "$strStakedAlias", stakedSymbol: "$strStakedSymbol", rewardSymbol: "$strRewardSymbol", stakeTokenAddress: "$strStakeTokenAddress", rewardTokenAddress: "$strRewardTokenAddress", stakingModule: "$strStakingModule", apr: "$strAPR", tvl: "$strTVL", staked: "$strStaked", rewards: "$strRewards", stakeTokenPrice: "$strStakeTokenPrice", rewardTokenPrice: "$strRewardTokenPrice")''';
+  }
+
+  String? getAthleteTokenName() {
+    if (strStakedAlias.isEmpty) return null;
+    final tickers = strStakedAlias.split('-');
+    //we want athlete ticker not 'AX'
+    final athleteTicker = tickers[0] == 'AX' ? tickers[1] : tickers[0];
+    return TokenList.mapTickerToName(athleteTicker);
+  }
+
+  SupportedSport getAthleteSport() {
+    if (strStakedAlias.isEmpty) return SupportedSport.all;
+    final tickers = strStakedAlias.split('-');
+    //we want athlete ticker not 'AX'
+    final athleteTicker = tickers[0] == 'AX' ? tickers[1] : tickers[0];
+    return TokenList.mapTickerToSport(athleteTicker);
   }
 }

--- a/lib/service/controller/farms/farm_controller.dart
+++ b/lib/service/controller/farms/farm_controller.dart
@@ -5,7 +5,6 @@ import 'package:ax_dapp/contracts/Pool.g.dart';
 import 'package:ax_dapp/pages/farm/models/farm_model.dart';
 import 'package:ax_dapp/service/controller/controller.dart';
 import 'package:ax_dapp/service/controller/wallet_controller.dart';
-import 'package:ax_dapp/service/token_list.dart';
 import 'package:ax_dapp/util/supported_sports.dart';
 import 'package:ax_dapp/util/user_input_info.dart';
 import 'package:get/get.dart';

--- a/lib/service/controller/farms/farm_controller.dart
+++ b/lib/service/controller/farms/farm_controller.dart
@@ -17,8 +17,8 @@ class FarmController {
   FarmController(FarmModel farm) {
     strAddress = farm.strAddress;
     strName = farm.strName;
-    athlete = _getAthleteTokenNameFromAlias(farm.strStakedAlias);
-    sport = _getAthleteSportFromAlias(farm.strStakedAlias);
+    athlete = farm.getAthleteTokenName();
+    sport = farm.getAthleteSport();
     strAPR = double.parse(farm.strAPR).toStringAsFixed(2);
     strTVL = double.parse(farm.strTVL).toStringAsFixed(2);
     strStaked = RxString(farm.strStaked);
@@ -71,26 +71,6 @@ class FarmController {
     final account = controller.publicAddress.value.hex;
     updateStakedBalance(account);
     updateCurrentBalance();
-  }
-
-  String? _getAthleteTokenNameFromAlias(String stakingAlias) {
-    // returns athlete token name, returns null if stakingAlias is empty
-    // stakingToken alias example: 'AJLT1010-AX' or 'AX-CCST1010' or ''
-    if (stakingAlias.isEmpty) return null;
-    final tickers = stakingAlias.split('-');
-    //we want athlete ticker not 'AX'
-    final athleteTicker = tickers[0] == 'AX' ? tickers[1] : tickers[0];
-    return TokenList.mapTickerToName(athleteTicker);
-  }
-
-  SupportedSport _getAthleteSportFromAlias(String stakingAlias) {
-    // returns athlete token name, returns null if stakingAlias is empty
-    // stakingToken alias example: 'AJLT1010-AX' or 'AX-CCST1010' or ''
-    if (stakingAlias.isEmpty) return SupportedSport.all;
-    final tickers = stakingAlias.split('-');
-    //we want athlete ticker not 'AX'
-    final athleteTicker = tickers[0] == 'AX' ? tickers[1] : tickers[0];
-    return TokenList.mapTickerToSport(athleteTicker);
   }
 
   // decalaration of member varibles


### PR DESCRIPTION
# Description
Display info text if search result is empty on farm page.

Fixes Jira Ticket #
AX-639

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

# Is this a UI Change? If so please include screenshot of before and after states below
Before:
![image](https://user-images.githubusercontent.com/71332959/185507934-8e1ec203-1a98-4409-8502-4bd64e033734.png)

After:
![image](https://user-images.githubusercontent.com/71332959/185508000-d89e77ec-6b8c-4d89-8acb-0a2e1198aadd.png)

# How Has This Been Tested?
1. Go to dashboard
2. Tap on farm page
3. Input random string which is not matched any farms on search widget
4. "No farms to display" text will be appeared

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have assigned 2 reviewers to check my work
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
