### PR TITLE
AX-928 [Farm] - Show warning popup like other page when user try to Stake without connecting to the wallet

### DIFF
--- a/lib/pages/farm/components/single_logo_farm_title.dart
+++ b/lib/pages/farm/components/single_logo_farm_title.dart
@@ -5,7 +5,10 @@ import 'package:ax_dapp/pages/farm/dialogs/stake_dialog.dart';
 import 'package:ax_dapp/pages/farm/modules/box_decoration.dart';
 import 'package:ax_dapp/pages/farm/modules/page_text_style.dart';
 import 'package:ax_dapp/service/controller/farms/farm_controller.dart';
+import 'package:ax_dapp/util/toast_extensions.dart';
 import 'package:flutter/material.dart';
+import 'package:ax_dapp/wallet/bloc/wallet_bloc.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 
 Widget singleLogoFarmTitle(
   BuildContext context,
@@ -46,15 +49,23 @@ Widget singleLogoFarmTitle(
             Colors.amber[600]!,
           ),
           child: TextButton(
-            onPressed: () => showDialog<void>(
-              context: context,
-              builder: (BuildContext builderContext) => StakeDialog(
-                context: builderContext,
-                farm: farm,
-                layoutWdt: cardWidth,
-                isWeb: isWeb,
-              ),
-            ),
+            onPressed: () {
+              final isWalletConnected =
+                  context.read<WalletBloc>().state.isWalletConnected;
+              if (isWalletConnected) {
+                showDialog<void>(
+                  context: context,
+                  builder: (BuildContext builderContext) => StakeDialog(
+                    context: builderContext,
+                    farm: farm,
+                    layoutWdt: cardWidth,
+                    isWeb: isWeb,
+                  ),
+                );
+              } else {
+                context.showWalletWarningToast();
+              }
+            },
             child: Text(
               'Stake',
               style: textStyle(Colors.black, 14, true, false),


### PR DESCRIPTION
# Description
Showed warning popup like other page when user try to Stake without connecting to the wallet
Fixes Jira Ticket AX-928

## Type of change
Please delete options that are not relevant.
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Is this a UI Change? If so please include screenshot of before and after states below
![image](https://user-images.githubusercontent.com/99713237/189126800-60488ca4-4eb9-49f0-a6dc-5e6958cdcca2.png)

# How Has This Been Tested?
I tested it on my chrome browser.

# Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have assigned 2 reviewers to check my work
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
