### PR TITLE
fix: removed duplicate definition in the api files

### DIFF
--- a/lib/service/api/mlb_athlete_api.dart
+++ b/lib/service/api/mlb_athlete_api.dart
@@ -45,14 +45,6 @@ abstract class MLBAthleteAPI {
     @Query('interval') String interval,
   );
 
-  @GET('/players/{id}/history/price')
-  Future<AthletePriceRecord> getPlayerPriceHistory(
-    @Path() int id,
-    @Query('from') String? from,
-    @Query('until') String? until,
-    @Query('interval') String interval,
-  );
-
   @POST('/players/history')
   Future<List<MLBAthleteStats>> getPlayersHistory(
     @Body() PlayerIds playerIds,

--- a/lib/service/api/nfl_athlete_api.dart
+++ b/lib/service/api/nfl_athlete_api.dart
@@ -38,12 +38,6 @@ abstract class NFLAthleteAPI {
       @Query('until') String until,);
 
   @GET('/players/{id}/history/price')
-  Future<AthletePriceRecord> getPlayerPriceHistory(@Path() int id,
-      @Query('from') String? from,
-      @Query('until') String? until,
-      @Query('interval') String? interval,);
-
-  @GET('/players/{id}/history/price')
   Future<AthletePriceRecord> getPlayerPriceHistory(
     @Path() int id,
     @Query('from') String? from,


### PR DESCRIPTION
# Description
Removes duplicate `getPlayerPriceHistory` definition from the `mlb_athlete_api.dart` and `nfl_athlete_api.dart`