### PR TITLE
fix: wallet address and ax units are now read when connecting the wallet

### DIFF
--- a/lib/wallet/widgets/dialogs/wallet_dialog.dart
+++ b/lib/wallet/widgets/dialogs/wallet_dialog.dart
@@ -1,5 +1,7 @@
 import 'package:ax_dapp/dialogs/promo/connected_wallet_promo_dialog.dart';
 import 'package:ax_dapp/pages/connect_wallet/mobile_login_page.dart';
+import 'package:ax_dapp/service/tracking/tracking_cubit.dart';
+import 'package:ax_dapp/util/helper.dart';
 import 'package:ax_dapp/wallet/bloc/wallet_bloc.dart';
 import 'package:ax_dapp/wallet/widgets/dialogs/connect_metamask_dialog.dart';
 import 'package:ax_dapp/wallet/widgets/dialogs/wrong_network_dialog.dart';
@@ -36,6 +38,12 @@ class WalletDialog extends StatelessWidget {
                 context: context,
                 builder: (context) => const ConnectedWalletPromoDialog(),
               );
+              final walletAddress =
+                  context.read<WalletBloc>().state.formattedWalletAddress;
+              context.read<TrackingCubit>().onConnectWalletSuccessful(
+                    publicAddress: walletAddress,
+                    axUnits: '"${toDecimal(state.axData.balance!, 6)} AX"',
+                  );
             }
           },
         ),


### PR DESCRIPTION
# Description
reads the wallet address on firebase when connecting the wallet

Fixes Jira Ticket # 

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Is this a UI Change? If so please include screenshot of before and after states below

# How Has This Been Tested?
Ran the app on chrome and tested the event by connecting to the wallet address

# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have assigned 2 reviewers to check my work
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
